### PR TITLE
module-04.adoc: Fix name of poi-map source root directory

### DIFF
--- a/content/modules/ROOT/pages/module-04.adoc
+++ b/content/modules/ROOT/pages/module-04.adoc
@@ -440,7 +440,7 @@ servers:
 +
 Save this file after applying the modification.
 +
-. Go into the project repository’s root folder, `{namespace}-poi-backend`, then open the file `src/main/resources/application.properties`. Scroll down to line 30 and specify the cluster internal service name (see `TODO` section in the next example).
+. Go into the project repository’s root folder, `{namespace}-poi-map`, then open the file `src/main/resources/application.properties`. Scroll down to line 30 and specify the cluster internal service name (see `TODO` section in the next example).
 +
 [source,yaml,subs="attributes"]
 ----


### PR DESCRIPTION
frontend step 7 second section s/poi-backend/poi-map/. Fixes Naveen report[1] item #4

[1]: https://docs.google.com/document/d/15FziBRgButBpfRU8WP7acUpi87hJKQ0vKb2ZTtgYLeE/edit